### PR TITLE
Add Glowstone to minecraft_flavours.yml

### DIFF
--- a/config/minecraft_flavours.yml
+++ b/config/minecraft_flavours.yml
@@ -128,3 +128,11 @@ tppi:
     notes:
         - 2GB+ recommended
         - This script is not updated frequently!
+glowstone:
+    versions:
+        - { name: Glowstone, tag: "null" }
+    time: 1
+    developers:
+        - The Glowstone Project
+    website: https://www.glowstone.net/
+    notes: []


### PR DESCRIPTION
Adds Glowstone to Gamocosm, using the script added in the scripts PR: https://github.com/Gamocosm/gamocosm-minecraft-flavours/pull/15.