### PR TITLE
Add papermc 1.15.2 and 1.14.4

### DIFF
--- a/config/minecraft_flavours.yml
+++ b/config/minecraft_flavours.yml
@@ -79,6 +79,8 @@ spigot:
         - This involves a long build process. It occasionally fails and you can try again or install it manually
 papermc:
     versions:
+        - { name: PaperMC (1.15.2), tag: 1.15.2 }
+        - { name: PaperMC (1.14.4), tag: 1.14.4 }
         - { name: PaperMC (1.13.2), tag: 1.13.2 }
         - { name: PaperMC (1.12.2), tag: 1.12.2 }
     time: 1


### PR DESCRIPTION
I followed the instructions on [the wiki](https://github.com/Gamocosm/Gamocosm/wiki/Installing-different-versions-of-Minecraft#adding-official-support-for-new-servers) and I've tested the script by setting the MINECRAFT_FLAVOUR_VERSION variable. Hopefully this works