### PR TITLE
Add PaperMC for Minecraft 1.16

### DIFF
--- a/config/minecraft_flavours.yml
+++ b/config/minecraft_flavours.yml
@@ -72,6 +72,7 @@ spigot:
         - This involves a long build process. It occasionally fails and you can try again or install it manually
 papermc:
     versions:
+        - { name: PaperMC (1.16.3), tag: 1.16.3 }
         - { name: PaperMC (1.15.2), tag: 1.15.2 }
         - { name: PaperMC (1.14.4), tag: 1.14.4 }
         - { name: PaperMC (1.13.2), tag: 1.13.2 }

--- a/config/minecraft_flavours.yml
+++ b/config/minecraft_flavours.yml
@@ -72,7 +72,7 @@ spigot:
         - This involves a long build process. It occasionally fails and you can try again or install it manually
 papermc:
     versions:
-        - { name: PaperMC (1.16.3), tag: 1.16.3 }
+        - { name: PaperMC (1.16.4), tag: 1.16.4 }
         - { name: PaperMC (1.15.2), tag: 1.15.2 }
         - { name: PaperMC (1.14.4), tag: 1.14.4 }
         - { name: PaperMC (1.13.2), tag: 1.13.2 }


### PR DESCRIPTION
Noticed 1.16.3 was missing. Also, vanilla and spigot has a "latest" version, is that possible to have for PaperMC as well?