### PR TITLE
Fix for a couple of spelling mistakes

### DIFF
--- a/app/views/user_mailer/autoshutdown_error_email.html.erb
+++ b/app/views/user_mailer/autoshutdown_error_email.html.erb
@@ -13,6 +13,6 @@
 	<br /><br />
 	If you could submit a bug report on <%= link_to 'GitHub', issues_url %>, that would be greatly appreciated.
 	<br /><br />
-	We sincerely appologize for the inconvennience!
+	We sincerely apologize for the inconvenience!
 </body>
 </html>

--- a/app/views/user_mailer/autoshutdown_error_email.text.erb
+++ b/app/views/user_mailer/autoshutdown_error_email.text.erb
@@ -8,4 +8,4 @@ There may be more information under "Server Logs" on your server on Gamocosm.
 
 If you could submit a bug report on GitHub (<%= issues_url %>), that would be greatly appreciated.
 
-We sincerely appologize for the inconvennience!
+We sincerely apologize for the inconvenience!


### PR DESCRIPTION
Fixes the spelling of apologize and inconvenience in the auto-shutdown error email