### PR TITLE
Make FAQ more clear about stopping server

### DIFF
--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -60,13 +60,13 @@
 				If you're interested, check this <%= link_to 'wiki page', wiki_server_additional_info_path %> for more info on the setup.</p>
 
 				<p><strong>Secondly, Digital Ocean continues charging you when you <em>just</em> stop a server</strong>, because its resources are still allocated.
-				When you stop a server on Gamocosm, it snapshots (backs up), and destroys your server.
-				When you restart a server, Gamocosm recreates it from the snapshot.
+				When you turn off a server on Gamocosm, it snapshots (backs up), and destroys your server.
+				When you turn on a server, Gamocosm recreates it from the snapshot.
 				This way, you only pay when the server is in use.</p>
 			</dd>
 			<dt>That's a little confusing</dt>
 			<dd>
-				Just make sure you click "stop" on Gamocosm when you're done playing!
+				Just make sure you click "Turn off" on Gamocosm when you're done playing!
 			</dd>
 			<dt>Anything else I should know?</dt>
 			<dd>


### PR DESCRIPTION
The previous formatting felt a bit confusing. It mentions "just stopping" a server (which implies the mc server) the droplet is still active and will charge you since resources are allocated, just the mc server is off.

Then it mentions:
>When you **stop** a server on Gamocosm, it snapshots (backs up), and destroys your server. 

The "stop" button stops the mc server. The stop button for the actual droplet itself is called "Turn off".

>When you **restart** a server, Gamocosm recreates it from the snapshot.

Similarly, the start button for the droplet is not called start or restart, it's called "Turn on". The _Reboot_ (not restart) button exists when the droplet is online, and you want to restart the droplet. Restarting the droplet does not recreate the snapshot from what I know, it just restarts the droplet, it's never deleted.